### PR TITLE
[Feat/clusterer] 군집화를 통한 레시피 추천 로직 구현

### DIFF
--- a/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeRecommender.kt
+++ b/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeRecommender.kt
@@ -53,6 +53,6 @@ open class MemberRecipeRecommender(
     }
 
     open fun updateCluster() {
-        clusterer.initializeClustersAsync(memberRecipeRepository.findAll(), 1000)
+        clusterer.initializeClustersAsync(memberRecipeRepository.findAll(), 30)
     }
 }

--- a/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeRecommender.kt
+++ b/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeRecommender.kt
@@ -26,6 +26,7 @@ open class MemberRecipeRecommender(
 
         if(batchCount == BATCH_SIZE) {
             updateCluster()
+            batchCount = 0
         }
     }
 

--- a/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeRecommender.kt
+++ b/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeRecommender.kt
@@ -1,0 +1,14 @@
+package org.example.application.memberRecipe
+
+import KMeansClusterer
+import org.example.domain.memberRecipe.repository.MemberRecipeRepository
+import org.springframework.stereotype.Service
+
+@Service
+class MemberRecipeRecommender(
+    private val memberRecipeRepository: MemberRecipeRepository,
+    private val clusterer: KMeansClusterer
+) {
+
+
+}

--- a/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeRecommender.kt
+++ b/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeRecommender.kt
@@ -1,14 +1,57 @@
 package org.example.application.memberRecipe
 
 import KMeansClusterer
+import org.example.domain.cluster.repository.ClusterRecipeRepository
+import org.example.domain.memberRecipe.entity.MemberRecipe
+import org.example.domain.memberRecipe.event.AddMemberRecipeEvent
 import org.example.domain.memberRecipe.repository.MemberRecipeRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionalEventListener
+import java.util.UUID
 
 @Service
-class MemberRecipeRecommender(
+open class MemberRecipeRecommender(
     private val memberRecipeRepository: MemberRecipeRepository,
+    private val clusterRecipeRepository: ClusterRecipeRepository,
     private val clusterer: KMeansClusterer
 ) {
 
+    private val BATCH_SIZE = 100
+    private var batchCount = 0;
 
+    @TransactionalEventListener(AddMemberRecipeEvent::class)
+    fun countBatch(event: AddMemberRecipeEvent) {
+        batchCount++
+
+        if(batchCount == BATCH_SIZE) {
+            updateCluster()
+        }
+    }
+
+    @Transactional(readOnly = true)
+    open fun findRecommendingRecipeIdsByMemberId(memberId: UUID): List<UUID> {
+        val memberRecipeIds = findMemberRecipes(memberId)
+        val result = mutableListOf<UUID>()
+
+        memberRecipeIds.forEach { result.addAll(getRecipesInSameCluster(it.id)) }
+        return result
+    }
+
+    private fun findMemberRecipes(memberId: UUID): List<MemberRecipe> {
+        return memberRecipeRepository.findAllByMemberId(memberId)
+    }
+
+    private fun getRecipesInSameCluster(memberRecipeId: UUID): List<UUID> {
+        val clusteredRecipe = clusterRecipeRepository.findById(memberRecipeId).orElse(null) ?: return emptyList()
+        val clusterId = clusteredRecipe.clusterId
+        val clusteredRecipes = clusterRecipeRepository.findByClusterId(clusterId)
+        val recipeIds = clusteredRecipes.map { it.id }
+        val memberRecipeInCluster = memberRecipeRepository.findAllById(recipeIds)
+        return memberRecipeInCluster.map { it.recipeId }
+    }
+
+    open fun updateCluster() {
+        clusterer.initializeClustersAsync(memberRecipeRepository.findAll(), 1000)
+    }
 }

--- a/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeService.kt
+++ b/was/recipe/src/main/java/org/example/application/memberRecipe/MemberRecipeService.kt
@@ -3,7 +3,6 @@ package org.example.application.memberRecipe
 import org.example.domain.entity.Member
 import org.example.domain.memberRecipe.repository.MemberRecipeRepository
 import org.example.presentation.dto.response.MemberRecipeDataResponse
-import org.example.presentation.dto.response.RecipeDataResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 

--- a/was/recipe/src/main/java/org/example/application/recipe/RecipeService.kt
+++ b/was/recipe/src/main/java/org/example/application/recipe/RecipeService.kt
@@ -1,5 +1,6 @@
 package org.example.application.recipe
 
+import org.example.application.memberRecipe.MemberRecipeRecommender
 import org.example.domain.entity.Member
 import org.example.domain.memberRecipe.event.AddMemberRecipeEvent
 import org.example.domain.recipe.entity.Recipe
@@ -16,10 +17,11 @@ import kotlin.math.min
 @Service
 open class RecipeService(
     private val recipeRepository: RecipeRepository,
-    private val publisher: ApplicationEventPublisher
+    private val publisher: ApplicationEventPublisher,
+    private val memberRecipeRecommender: MemberRecipeRecommender
 ) {
 
-    private val recipeMap = HashMap<String, Recipe>();
+    private val recipeMap = HashMap<String, List<Recipe>>();
 
     @Transactional
     open fun findRecipeById(recipeId: UUID, member: Member): RecipeResponse {
@@ -41,7 +43,13 @@ open class RecipeService(
 
     @Transactional(readOnly = true)
     open fun findAllRecipe(): List<RecipeDataResponse> {
-        return recipeRepository.findAll().map{ each -> RecipeDataResponse(each) }
+        return recipeRepository.findAll().map{ RecipeDataResponse(it) }
+    }
+
+    @Transactional(readOnly = true)
+    open fun findRecommendableRecipes(member: Member): List<RecipeDataResponse> {
+        val recipes = recipeRepository.findAllById(memberRecipeRecommender.findRecommendingRecipeIdsByMemberId(member.id))
+        return recipes.map{ RecipeDataResponse(it) }
     }
 
     @Transactional(readOnly = true)

--- a/was/recipe/src/main/java/org/example/config/ClusterConfig.kt
+++ b/was/recipe/src/main/java/org/example/config/ClusterConfig.kt
@@ -1,0 +1,20 @@
+package org.example.config
+
+import KMeansClusterer
+import org.example.infrastructure.DataProcessor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class ClusterConfig {
+
+    @Bean
+    open fun dataProcessor(): DataProcessor {
+        return DataProcessor()
+    }
+
+    @Bean
+    open fun cluster(): KMeansClusterer {
+        return KMeansClusterer(dataProcessor())
+    }
+}

--- a/was/recipe/src/main/java/org/example/domain/cluster/entity/ClusterRecipe.kt
+++ b/was/recipe/src/main/java/org/example/domain/cluster/entity/ClusterRecipe.kt
@@ -1,0 +1,17 @@
+package org.example.domain.cluster.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import java.util.UUID
+
+@Entity
+class ClusterRecipe(
+    @Id
+    val id: UUID,
+    val clusterId: Int
+){
+
+    constructor(): this(UUID.randomUUID(), 0)
+
+    constructor(clusterId: Int): this(UUID.randomUUID(), clusterId)
+}

--- a/was/recipe/src/main/java/org/example/domain/cluster/repository/ClusterRecipeRepository.kt
+++ b/was/recipe/src/main/java/org/example/domain/cluster/repository/ClusterRecipeRepository.kt
@@ -1,0 +1,9 @@
+package org.example.domain.cluster.repository
+
+import org.example.domain.cluster.entity.ClusterRecipe
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ClusterRecipeRepository: JpaRepository<ClusterRecipe, UUID> {
+    fun findByClusterId(clusterId: Int): List<ClusterRecipe>
+}

--- a/was/recipe/src/main/java/org/example/infrastructure/DataProcessor.kt
+++ b/was/recipe/src/main/java/org/example/infrastructure/DataProcessor.kt
@@ -3,8 +3,9 @@ package org.example.infrastructure
 import org.example.domain.enums.Age
 import org.example.domain.enums.Gender
 import org.example.domain.memberRecipe.entity.MemberRecipe
+import org.springframework.stereotype.Component
 
-
+@Component
 class DataProcessor() {
 
     fun transformData(recipe: MemberRecipe): DoubleArray {

--- a/was/recipe/src/main/java/org/example/infrastructure/DoubleArrayWrapper.kt
+++ b/was/recipe/src/main/java/org/example/infrastructure/DoubleArrayWrapper.kt
@@ -1,0 +1,10 @@
+package org.example.infrastructure
+
+import org.apache.commons.math3.ml.clustering.Clusterable
+
+
+class DoubleArrayWrapper(private val points: DoubleArray) : Clusterable {
+    override fun getPoint(): DoubleArray {
+        return points
+    }
+}

--- a/was/recipe/src/main/java/org/example/infrastructure/KMeansClusterer.kt
+++ b/was/recipe/src/main/java/org/example/infrastructure/KMeansClusterer.kt
@@ -1,31 +1,31 @@
-package org.example.infrastructure
-
-import org.apache.commons.math3.ml.clustering.*
+import org.apache.commons.math3.ml.clustering.CentroidCluster
+import org.apache.commons.math3.ml.clustering.KMeansPlusPlusClusterer
 import org.apache.commons.math3.ml.distance.EuclideanDistance
 import org.example.domain.memberRecipe.entity.MemberRecipe
-import org.springframework.stereotype.Service
+import org.example.infrastructure.DataProcessor
+import org.example.infrastructure.DoubleArrayWrapper
 import java.util.*
 
-
-@Service
 class KMeansClusterer(
+    private val dataProcessor: DataProcessor
 ) {
-    fun clusterData(data: List<DoubleArray>?, numClusters: Int): List<CentroidCluster<DoubleArray>> {
-        val clusterer: KMeansPlusPlusClusterer<DoubleArray> =
-            KMeansPlusPlusClusterer(numClusters, 1000, EuclideanDistance())
-        return clusterer.cluster(data)
+
+    fun clusterData(data: List<DoubleArray>?, numClusters: Int): List<CentroidCluster<DoubleArrayWrapper>> {
+        val clusterableData = data?.map { DoubleArrayWrapper(it) } ?: emptyList()
+        val clusterer = KMeansPlusPlusClusterer<DoubleArrayWrapper>(numClusters, 1000, EuclideanDistance())
+        return clusterer.cluster(clusterableData)
     }
 
     fun findClusterIndexForRecipe(
         recipeId: UUID,
-        clusters: List<CentroidCluster<DoubleArray>>,
+        clusters: List<CentroidCluster<DoubleArrayWrapper>>,
         recipes: List<MemberRecipe>
     ): Int {
         for (i in clusters.indices) {
-            for (point in clusters[i].getPoints()) {
+            for (point in clusters[i].points) {
                 val pointArray = point.point
                 for (recipe in recipes) {
-                    val recipeArray = doubleArrayOf(ageToDouble(recipe.memberAge), genderToDouble(recipe.gender))
+                    val recipeArray = dataProcessor.transformData(recipe)
                     if (Arrays.equals(pointArray, recipeArray) && recipe.recipeId == recipeId) {
                         return i
                     }
@@ -37,24 +37,25 @@ class KMeansClusterer(
 
     fun getRecipesInSameCluster(
         recipeId: UUID,
-        clusters: List<CentroidCluster<DoubleArray>>,
+        clusters: List<CentroidCluster<DoubleArrayWrapper>>,
         recipes: List<MemberRecipe>
     ): List<MemberRecipe> {
         val clusterIndex = findClusterIndexForRecipe(recipeId, clusters, recipes)
         if (clusterIndex == -1) {
-            return Collections.emptyList()
+            return emptyList()
         }
 
         val sameClusterRecipes: MutableList<MemberRecipe> = ArrayList()
-        for (point in clusters[clusterIndex].getPoints()) {
+        for (point in clusters[clusterIndex].points) {
             val pointArray = point.point
             for (recipe in recipes) {
-                val recipeArray = doubleArrayOf(ageToDouble(recipe.memberAge), genderToDouble(recipe.gender))
+                val recipeArray = dataProcessor.transformData(recipe)
                 if (Arrays.equals(pointArray, recipeArray)) {
                     sameClusterRecipes.add(recipe)
                 }
             }
         }
+
         return sameClusterRecipes
     }
 }

--- a/was/recipe/src/main/java/org/example/infrastructure/KMeansClusterer.kt
+++ b/was/recipe/src/main/java/org/example/infrastructure/KMeansClusterer.kt
@@ -4,8 +4,10 @@ import org.apache.commons.math3.ml.distance.EuclideanDistance
 import org.example.domain.memberRecipe.entity.MemberRecipe
 import org.example.infrastructure.DataProcessor
 import org.example.infrastructure.DoubleArrayWrapper
+import org.springframework.stereotype.Component
 import java.util.*
 
+@Component
 class KMeansClusterer(
     private val dataProcessor: DataProcessor
 ) {
@@ -14,25 +16,6 @@ class KMeansClusterer(
         val clusterableData = data?.map { DoubleArrayWrapper(it) } ?: emptyList()
         val clusterer = KMeansPlusPlusClusterer<DoubleArrayWrapper>(numClusters, 1000, EuclideanDistance())
         return clusterer.cluster(clusterableData)
-    }
-
-    fun findClusterIndexForRecipe(
-        recipeId: UUID,
-        clusters: List<CentroidCluster<DoubleArrayWrapper>>,
-        recipes: List<MemberRecipe>
-    ): Int {
-        for (i in clusters.indices) {
-            for (point in clusters[i].points) {
-                val pointArray = point.point
-                for (recipe in recipes) {
-                    val recipeArray = dataProcessor.transformData(recipe)
-                    if (Arrays.equals(pointArray, recipeArray) && recipe.recipeId == recipeId) {
-                        return i
-                    }
-                }
-            }
-        }
-        return -1 // 클러스터를 찾지 못한 경우
     }
 
     fun getRecipesInSameCluster(
@@ -57,5 +40,24 @@ class KMeansClusterer(
         }
 
         return sameClusterRecipes
+    }
+
+    fun findClusterIndexForRecipe(
+        recipeId: UUID,
+        clusters: List<CentroidCluster<DoubleArrayWrapper>>,
+        recipes: List<MemberRecipe>
+    ): Int {
+        for (i in clusters.indices) {
+            for (point in clusters[i].points) {
+                val pointArray = point.point
+                for (recipe in recipes) {
+                    val recipeArray = dataProcessor.transformData(recipe)
+                    if (Arrays.equals(pointArray, recipeArray) && recipe.recipeId == recipeId) {
+                        return i
+                    }
+                }
+            }
+        }
+        return -1 // 클러스터를 찾지 못한 경우
     }
 }

--- a/was/recipe/src/main/java/org/example/infrastructure/KMeansClusterer.kt
+++ b/was/recipe/src/main/java/org/example/infrastructure/KMeansClusterer.kt
@@ -1,63 +1,50 @@
+import jakarta.annotation.PostConstruct
 import org.apache.commons.math3.ml.clustering.CentroidCluster
 import org.apache.commons.math3.ml.clustering.KMeansPlusPlusClusterer
 import org.apache.commons.math3.ml.distance.EuclideanDistance
+import org.example.domain.cluster.entity.ClusterRecipe
+import org.example.domain.cluster.repository.ClusterRecipeRepository
 import org.example.domain.memberRecipe.entity.MemberRecipe
 import org.example.infrastructure.DataProcessor
 import org.example.infrastructure.DoubleArrayWrapper
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import java.util.*
 
 @Component
-class KMeansClusterer(
-    private val dataProcessor: DataProcessor
+open class KMeansClusterer(
+    private val dataProcessor: DataProcessor,
+    private val clusteredRecipeRepository: ClusterRecipeRepository
 ) {
 
-    fun clusterData(data: List<DoubleArray>?, numClusters: Int): List<CentroidCluster<DoubleArrayWrapper>> {
-        val clusterableData = data?.map { DoubleArrayWrapper(it) } ?: emptyList()
-        val clusterer = KMeansPlusPlusClusterer<DoubleArrayWrapper>(numClusters, 1000, EuclideanDistance())
-        return clusterer.cluster(clusterableData)
+    private var clusters: List<CentroidCluster<DoubleArrayWrapper>> = emptyList()
+    private var recipeMap: Map<UUID, DoubleArray> = emptyMap()
+
+    @Async
+    open fun initializeClustersAsync(data: List<MemberRecipe>, numClusters: Int) {
+        clusters = clusterData(data, numClusters)
+        recipeMap = data.associateBy({ it.recipeId }, { dataProcessor.transformData(it) })
+
+        // 클러스터링 결과를 저장
+        saveClusterResults()
     }
 
-    fun getRecipesInSameCluster(
-        recipeId: UUID,
-        clusters: List<CentroidCluster<DoubleArrayWrapper>>,
-        recipes: List<MemberRecipe>
-    ): List<MemberRecipe> {
-        val clusterIndex = findClusterIndexForRecipe(recipeId, clusters, recipes)
-        if (clusterIndex == -1) {
-            return emptyList()
-        }
-
-        val sameClusterRecipes: MutableList<MemberRecipe> = ArrayList()
-        for (point in clusters[clusterIndex].points) {
-            val pointArray = point.point
-            for (recipe in recipes) {
-                val recipeArray = dataProcessor.transformData(recipe)
-                if (Arrays.equals(pointArray, recipeArray)) {
-                    sameClusterRecipes.add(recipe)
-                }
-            }
-        }
-
-        return sameClusterRecipes
-    }
-
-    fun findClusterIndexForRecipe(
-        recipeId: UUID,
-        clusters: List<CentroidCluster<DoubleArrayWrapper>>,
-        recipes: List<MemberRecipe>
-    ): Int {
+    private fun saveClusterResults() {
+        clusteredRecipeRepository.deleteAll()
+        val clusteredRecipes = mutableListOf<ClusterRecipe>()
         for (i in clusters.indices) {
             for (point in clusters[i].points) {
                 val pointArray = point.point
-                for (recipe in recipes) {
-                    val recipeArray = dataProcessor.transformData(recipe)
-                    if (Arrays.equals(pointArray, recipeArray) && recipe.recipeId == recipeId) {
-                        return i
-                    }
-                }
+                val recipeId = recipeMap.entries.find { Arrays.equals(it.value, pointArray) }?.key
+                recipeId?.let { clusteredRecipes.add(ClusterRecipe(it, i)) }
             }
         }
-        return -1 // 클러스터를 찾지 못한 경우
+        clusteredRecipeRepository.saveAll(clusteredRecipes)
+    }
+
+    fun clusterData(data: List<MemberRecipe>, numClusters: Int): List<CentroidCluster<DoubleArrayWrapper>> {
+        val clusterableData = data.map { DoubleArrayWrapper(dataProcessor.transformData(it)) } ?: emptyList()
+        val clusterer = KMeansPlusPlusClusterer<DoubleArrayWrapper>(numClusters, 1000, EuclideanDistance())
+        return clusterer.cluster(clusterableData)
     }
 }

--- a/was/recipe/src/main/java/org/example/presentation/RecipeController.kt
+++ b/was/recipe/src/main/java/org/example/presentation/RecipeController.kt
@@ -44,4 +44,10 @@ class RecipeController(
         val recipes = memberRecipeService.findMyRecipes(member)
         return ResponseEntity<MemberRecipeDataListResponse>(MemberRecipeDataListResponse(recipes), HttpStatus.OK)
     }
+
+    @GetMapping("/recommend")
+    fun findRecommendedRecipes(@JwtLogin member: Member): ResponseEntity<RecipeDataListResponse> {
+        val recipes = recipeService.findRecommendableRecipes(member)
+        return ResponseEntity<RecipeDataListResponse>(RecipeDataListResponse(recipes), HttpStatus.OK)
+    }
 }


### PR DESCRIPTION
- 배치 크기는 100개로 설정

- 100개가 할당되면 군집화 알고리즘 수행
    - 해당 기능은 비동기적으로 동작하도록 구현

- 수행된 데이터는 DB에 추가

- API 요청시에 플로우
    - memberID를 이용해 MemberRecipe를 가져온다. 
    - MemberRecipe.id를 가져와 같은 군집의 ClusterRecipe를 가져온다. 
    - ClusterRecipe.cluster값을 가져와 같은 cluster의 ClusterRecipe.id들을 가져올 수 있다. (해당 id는 MemberRecipe.id와 동일하다)
    - MemberRecipe들을 조회한 후, recipeId로 가져온다. 
    - recipeId를 통해 Recipe객체들을 가져와 dto로 반환한다